### PR TITLE
Fix: address full-image-container spill and overflow w/ aspect-ratio

### DIFF
--- a/src/_sass/_components.scss
+++ b/src/_sass/_components.scss
@@ -268,8 +268,7 @@ footer.main {
 	padding-top: var(--space-size-xs);
 	position: relative;
 	color: var(--on-dark-text);
-	min-height: 600px;
-	max-height: 1000px;
+	aspect-ratio: 16 / 9;
 
 	.full-image {
 		object-fit: cover;


### PR DESCRIPTION
Depending on the screen size `min-height`/`max-height` were causing images to obscure critical interface elements and introducing gaps beneath the container. `aspect-ratio` achieves a superior effect w/o any of these undesirable behaviors.

```diff
.full-image-container {
-	min-height: 600px;
-	max-height: 1000px;
+	aspect-ratio: 16 / 9;
```

## Screenshots

| BEFORE  | AFTER |
| --- | --- |
| ![BEFORE-1728px-2024-08-02-1146](https://github.com/user-attachments/assets/02d22fbb-632d-475e-881c-b6d3a3877dc4) | ![AFTER-1728px-2024-08-02-1138](https://github.com/user-attachments/assets/f3f18a0c-851b-4d50-82c0-1af9277acc87) |
| **1728px W** @ 2x = 3456px W reduced 2/3 to 1152px W for GitHub, 107K | **1728px W** @ 2x = 3456px W reduced 2/3 to 1152px W for GitHub, 98K |
| ![BEFORE-664px-2024-08-02-1147](https://github.com/user-attachments/assets/70f47876-39d4-4a32-b668-41f862aee9f4) | ![AFTER-664px-2024-08-02-1147](https://github.com/user-attachments/assets/38287b64-3569-4d20-927f-6b1a684b3320)
| **664px W** @ 2x = 1328px W reduced 1/2 to 664px W for GitHub, 70K | **664px W** @ 2x = 1328px W reduced 1/2 to 664px W for GitHub, 67K  |

PS Love the auto-generated name of the live demo: https://endless-iris.cloudvent.net/ ♾️ 👁️ 