### PR TITLE
Fix: dropdown-menu highlight overview links

### DIFF
--- a/src/_data/main_nav.yml
+++ b/src/_data/main_nav.yml
@@ -3,7 +3,7 @@
 		"title": "Admissions",
 		"overview": {
 			"title": "Admissions Overview",
-			"link": "/admission-overview",
+			"link": "#",
 			"media": {
 				"image": "/assets/students.jpg",
 				"alt": "Students in the admissions office"
@@ -75,7 +75,7 @@
 		"title": "Academics",
 		"overview": {
 			"title": "Academics Overview",
-			"link": "/academics-overview",
+			"link": "#",
 			"media": {
 				"image": "/assets/studying.jpg",
 				"alt": "Students studying"

--- a/src/_includes/nav/_main.html
+++ b/src/_includes/nav/_main.html
@@ -12,7 +12,7 @@
   <div class="dropdown-menu" id="dropdown-{{ forloop.index }}">
 	<div class="dropdown-content" >
 	  <section class="highlight">
-		<a href="{{ nav_item.overview.title }}">
+		<a href="{{ nav_item.overview.link }}">
 		  <div class="media">
 			{% image nav_item.overview.media.image nav_item.overview.media.alt 300 %}
 		  </div>

--- a/src/_includes/nav/_mobile.html
+++ b/src/_includes/nav/_mobile.html
@@ -21,7 +21,7 @@
 			<div class="dropdown-menu" id="inner-mobile-menu-{{ forloop.index }}">
 				<div class="inner-mobile-menu">
 					<section class="highlight">
-						<a href="{{ nav_item.overview.title }}">
+						<a href="{{ nav_item.overview.link }}">
 							{{ nav_item.overview.title }}
 						</a>
 					</section>


### PR DESCRIPTION
nav (main_nav) .dropdown-menu section.highlight links were using nav_item.overview.title instead of nav_item.overview.link and some of the data in main_nav.yml pointed to nonexistent pages.